### PR TITLE
(#113) Update Site Deployer

### DIFF
--- a/.github/workflows/composite/setup/action.yml
+++ b/.github/workflows/composite/setup/action.yml
@@ -31,7 +31,7 @@ runs:
       working-directory: site
       shell: pwsh
       run: |
-          Invoke-WebRequest -Uri "https://github.com/user-attachments/files/18969562/6.0.2301.1506-Akumina.SiteDeployer.zip" -OutFile "sd.zip"
+          Invoke-WebRequest -Uri "https://github.com/akumina/SiteDeployer/releases/download/6.0.2301.1508/6.0.2301.1508-Akumina.SiteDeployer.zip" -OutFile "sd.zip"
           $ExtractPath = "tools"
           if (-not (Test-Path -Path $ExtractPath)) {
               New-Item -ItemType Directory -Path $ExtractPath | Out-Null


### PR DESCRIPTION
Update Site Deployer to v1508 and change the download location back to GitHub releases.

Closes #113